### PR TITLE
Changes from Cliffle review

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,13 @@ future_incompatible = "warn"
 nonstandard_style = "warn"
 rust_2018_idioms = "warn"
 
+# via cliffle
+# don't silently tolerate unsafe code inside functions marked unsafe
+# will be default in Rust 2024, it sounds like
+unsafe_op_in_unsafe_fn = "deny"
+# avoid obfuscated lifetimes 
+elided_lifetimes_in_paths = "deny"
+
 [workspace.lints.rustdoc]
 missing_crate_level_docs = "warn"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It's initially intended as a learning project with aspirations to be generally u
 
 Current status: Most chunks from the initial WAV spec [RIFF1991](https://wavref.til.cafe/spec/riff1991/) are supported. Only supports reading metadata. Doesn't yet support writing metadata. Doesn't yet read or write audio data (samples). 
 
-I intend to evntually support every WAV chunk I can find a sample of. If there's something you'd like supported, please let me know by adding [an issue](https://github.com/briandorsey/wavrw/issues). If you have them, please include a link to a specification and one or more example files.
+I intend to eventually support every WAV chunk I can find a sample of. If there's something you'd like supported, please let me know by adding [an issue](https://github.com/briandorsey/wavrw/issues). If you have them, please include a link to a specification and one or more example files.
 
 Take care,
 -Brian

--- a/wavrw-cli/src/bin/wavrw.rs
+++ b/wavrw-cli/src/bin/wavrw.rs
@@ -295,6 +295,7 @@ fn walk_paths(base_path: &PathBuf, config: &ListConfig) -> Result<()> {
             eprintln!("directory: {}", path.to_string_lossy());
             walk_paths(&path, config)?;
         } else if let Some(ext) = path.extension() {
+            // config.ext entries are assumed to have been converted to lowercase already.
             let ext = ext.to_ascii_lowercase();
             if !config.ext.contains(&ext) {
                 continue;
@@ -337,7 +338,7 @@ fn main() -> Result<()> {
         Commands::View(config) => view(config),
 
         Commands::List(config) => {
-            // TODO: figure out how to do this in CLAP
+            // Convert extensions to lowercase for case insensitive comparison later.
             for ext in &mut config.ext {
                 ext.make_ascii_lowercase();
             }

--- a/wavrw-cli/src/bin/wavrw.rs
+++ b/wavrw-cli/src/bin/wavrw.rs
@@ -2,12 +2,12 @@
 
 #![deny(missing_docs)]
 
-use std::ffi::OsString;
 use std::fmt::Write;
 use std::fs;
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
+use std::{ffi::OsString, io::BufReader};
 
 use anyhow::Result;
 use clap::{crate_version, ArgAction, Parser, Subcommand, ValueEnum};
@@ -156,6 +156,7 @@ fn view(config: &ViewConfig) -> Result<()> {
 
         print!("{}: ", path.to_string_lossy());
         let file = File::open(path)?;
+        let file = BufReader::new(file);
 
         match config.format {
             Format::Line => {
@@ -172,7 +173,7 @@ fn view(config: &ViewConfig) -> Result<()> {
     Ok(())
 }
 
-fn view_line(file: File) -> Result<String> {
+fn view_line(file: BufReader<File>) -> Result<String> {
     let mut out = String::new();
     let mut chunk_strings: Vec<String> = vec![];
 
@@ -205,7 +206,7 @@ fn view_line(file: File) -> Result<String> {
     Ok(out)
 }
 
-fn view_summary(file: File, config: &ViewConfig) -> Result<String> {
+fn view_summary(file: BufReader<File>, config: &ViewConfig) -> Result<String> {
     let mut out = "\n".to_string();
     writeln!(out, "      offset id              size summary")?;
 
@@ -238,7 +239,7 @@ fn view_summary(file: File, config: &ViewConfig) -> Result<String> {
     Ok(out)
 }
 
-fn view_detailed(file: File) -> Result<String> {
+fn view_detailed(file: BufReader<File>) -> Result<String> {
     let mut out = "\n".to_string();
     writeln!(out, "      offset id              size summary")?;
 
@@ -300,6 +301,7 @@ fn walk_paths(base_path: &PathBuf, config: &ListConfig) -> Result<()> {
             }
 
             let file = File::open(path.clone())?;
+            let file = BufReader::new(file);
             let path_name = path.to_string_lossy();
 
             match view_line(file) {

--- a/wavrw/src/lib.md
+++ b/wavrw/src/lib.md
@@ -6,7 +6,9 @@ Iterate over all dyn [`SizedChunk`] chunk objects from a file:
 
 ```
 # use std::fs::File;
+# use std::io::BufReader; 
 let file = File::open("../test_wavs/example_a.wav")?;
+let file = BufReader::new(file);
 let mut wave = wavrw::Wave::new(file)?;
 for result in wave.metadata_chunks()? {
     match result {


### PR DESCRIPTION
With huge thanks to @cbiffle for the review, several updates:

* added lints: `unsafe_op_in_unsafe_fn`, `elided_lifetimes_in_paths`
* Use a trait bound for the reader in `Wav.data` instead of wrapping it in a `BufReader` in the constructor.
* Updated comments about lowercasing `--ext` for comparisons.

Spent an hour or so trying to convert a clap arg from a Vec<T> to a BTreeSet<T>... and failed. Asked in the clap forums: https://github.com/clap-rs/clap/discussions/5437