### PR TITLE
Rework high-level chunks API

### DIFF
--- a/wavrw-cli/src/bin/wavrw.rs
+++ b/wavrw-cli/src/bin/wavrw.rs
@@ -185,7 +185,7 @@ fn view_line(file: BufReader<File>) -> Result<String> {
     let mut out = String::new();
     let mut chunk_strings: Vec<String> = vec![];
 
-    let mut wave = wavrw::Wave::new(file)?;
+    let mut wave = wavrw::Wave::from_reader(file)?;
 
     for result in wave.iter_chunks() {
         match result {
@@ -210,7 +210,7 @@ fn view_summary(file: BufReader<File>, config: &ViewConfig) -> Result<String> {
     let mut out = "\n".to_string();
     writeln!(out, "      offset id              size summary")?;
 
-    let mut wave = wavrw::Wave::new(file)?;
+    let mut wave = wavrw::Wave::from_reader(file)?;
     for result in wave.iter_chunks() {
         match result {
             Ok(chunk) => {
@@ -243,7 +243,7 @@ fn view_detailed(file: BufReader<File>) -> Result<String> {
     let mut out = "\n".to_string();
     writeln!(out, "      offset id              size summary")?;
 
-    let mut wave = wavrw::Wave::new(file)?;
+    let mut wave = wavrw::Wave::from_reader(file)?;
     for result in wave.iter_chunks() {
         match result {
             Ok(chunk) => {

--- a/wavrw-cli/src/bin/wavrw.rs
+++ b/wavrw-cli/src/bin/wavrw.rs
@@ -331,12 +331,9 @@ fn topic(config: &mut TopicConfig) -> Result<()> {
 
 #[instrument]
 fn main() -> Result<()> {
-    // TODO: read about subscribers... seems like it's behaving differently now that I
-    // have #[instrument] in this file?!? Shouldn't the ones in lib have already been
-    // reporting? Weird.
     let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::TRACE)
         // TODO: --option to set log level and span events
+        .with_max_level(Level::TRACE)
         .with_span_events(FmtSpan::NONE)
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/wavrw-cli/src/bin/wavrw.rs
+++ b/wavrw-cli/src/bin/wavrw.rs
@@ -216,8 +216,8 @@ fn view_summary(file: BufReader<File>, config: &ViewConfig) -> Result<String> {
             Ok(chunk) => {
                 writeln!(
                     out,
-                    "{:12} {:9} {:10} {}",
-                    "offset".to_string(),
+                    "{:>12} {:9} {:10} {}",
+                    chunk.offset().map_or("???".to_string(), |v| v.to_string()),
                     chunk.name(),
                     chunk.size(),
                     trim(&chunk.summary(), config.width.saturating_sub(29))
@@ -226,8 +226,8 @@ fn view_summary(file: BufReader<File>, config: &ViewConfig) -> Result<String> {
             Err(err) => {
                 writeln!(
                     out,
-                    "{:12} {:9} {:10} {}",
-                    "offset".to_string(),
+                    "{:>12} {:9} {:10} {}",
+                    "???".to_string(),
                     "ERROR".to_string(),
                     "".to_string(),
                     trim(&err.to_string(), config.width.saturating_sub(29))
@@ -249,8 +249,8 @@ fn view_detailed(file: BufReader<File>) -> Result<String> {
             Ok(chunk) => {
                 writeln!(
                     out,
-                    "{:12} {:9} {:10} {}",
-                    "offset".to_string(),
+                    "{:>12} {:9} {:10} {}",
+                    chunk.offset().map_or("???".to_string(), |v| v.to_string()),
                     chunk.name(),
                     chunk.size(),
                     chunk.item_summary_header()
@@ -267,8 +267,8 @@ fn view_detailed(file: BufReader<File>) -> Result<String> {
             Err(err) => {
                 writeln!(
                     out,
-                    "{:12} {:9} {:10} {}",
-                    "offset".to_string(),
+                    "{:>12} {:9} {:10} {}",
+                    "???".to_string(),
                     "ERROR".to_string(),
                     "".to_string(),
                     err,

--- a/wavrw/src/chunk/cset.rs
+++ b/wavrw/src/chunk/cset.rs
@@ -274,6 +274,7 @@ mod test {
     #[test]
     fn cset_roundtrip() {
         let cset = Cset {
+            offset: Some(0),
             size: 8,
             data: CsetData {
                 code_page: 1,

--- a/wavrw/src/chunk/data.rs
+++ b/wavrw/src/chunk/data.rs
@@ -58,6 +58,7 @@ mod test {
 
         // validate data roundtrip
         let data = Data {
+            offset: Some(0),
             size: 0,
             data: DataData {
                 data: [8_u8; 0].to_vec(),

--- a/wavrw/src/chunk/fact.rs
+++ b/wavrw/src/chunk/fact.rs
@@ -1,6 +1,6 @@
 use binrw::binrw;
 
-use crate::{FourCC, KnownChunk, KnownChunkID, SizedChunk, Summarizable};
+use crate::{FourCC, KnownChunk, KnownChunkID, Summarizable};
 
 /// `fact` Number of samples for compressed audio in `data`. [RIFF1991](https://wavref.til.cafe/chunk/fact/)
 ///
@@ -18,12 +18,6 @@ pub struct FactData {
 
 impl KnownChunkID for FactData {
     const ID: FourCC = FourCC(*b"fact");
-}
-
-impl SizedChunk for FactData {
-    fn size(&self) -> u32 {
-        4
-    }
 }
 
 impl Summarizable for FactData {

--- a/wavrw/src/chunk/fmt.rs
+++ b/wavrw/src/chunk/fmt.rs
@@ -698,6 +698,7 @@ mod test {
     fn parse_fmt() {
         let mut buff = hex_to_cursor("666D7420 10000000 01000100 80BB0000 80320200 03001800");
         let expected = Fmt {
+            offset: Some(0),
             size: 16,
             data: FmtData {
                 format_tag: FormatTag::Pcm,

--- a/wavrw/src/chunk/fmt.rs
+++ b/wavrw/src/chunk/fmt.rs
@@ -711,7 +711,12 @@ mod test {
         };
         let chunk = Fmt::read(&mut buff).expect("error parsing WAV chunks");
         assert_eq!(chunk, expected);
-        // hexdump(remaining_input);
+
+        // make sure parsing via SizedChunkEnum also works
+        use crate::SizedChunkEnum;
+        buff.set_position(0);
+        let chunk = SizedChunkEnum::read(&mut buff).expect("error parsing WAV chunks");
+        assert_eq!(chunk, SizedChunkEnum::Fmt(expected));
     }
 
     #[test]

--- a/wavrw/src/chunk/info.rs
+++ b/wavrw/src/chunk/info.rs
@@ -365,6 +365,7 @@ mod test {
     #[test]
     fn infochunk_roundtrip() {
         let icmt = InfoEnum::Icmt(Icmt {
+            offset: Some(0),
             size: 8,
             data: IcmtData {
                 text: String::from("comment"),
@@ -436,6 +437,7 @@ mod test {
     #[test]
     fn icmtchunk_as_trait() {
         let icmt = Icmt {
+            offset: None,
             size: 8,
             data: IcmtData::new("comment"),
             extra_bytes: vec![],

--- a/wavrw/src/chunk/info.rs
+++ b/wavrw/src/chunk/info.rs
@@ -360,7 +360,7 @@ mod test {
     use hexdump::hexdump;
 
     use super::*;
-    use crate::{box_chunk, testing::hex_to_cursor, SizedChunk, SizedChunkEnum};
+    use crate::{testing::hex_to_cursor, SizedChunk, SizedChunkEnum};
 
     #[test]
     fn infochunk_roundtrip() {
@@ -417,7 +417,7 @@ mod test {
 
         // parse via enum wrapper this time
         buff.set_position(0);
-        let chunk = SizedChunkEnum::read(&mut buff).map(box_chunk).unwrap();
+        let chunk = SizedChunkEnum::read(&mut buff).unwrap();
         assert_eq!(chunk.id(), FourCC(*b"LIST"));
 
         // let list = ListInfo::read(&mut buff).unwrap();

--- a/wavrw/src/chunk/md5.rs
+++ b/wavrw/src/chunk/md5.rs
@@ -1,6 +1,6 @@
 use binrw::binrw;
 
-use crate::{FourCC, KnownChunk, KnownChunkID, SizedChunk, Summarizable};
+use crate::{FourCC, KnownChunk, KnownChunkID, Summarizable};
 
 /// `MD5 ` Checksum of audio `data` of the WAVE. [MD5_2017](https://wavref.til.cafe/chunk/md5/)
 ///
@@ -16,12 +16,6 @@ pub struct Md5Data {
 
 impl KnownChunkID for Md5Data {
     const ID: FourCC = FourCC(*b"MD5 ");
-}
-
-impl SizedChunk for Md5Data {
-    fn size(&self) -> u32 {
-        16
-    }
 }
 
 impl Summarizable for Md5Data {
@@ -45,6 +39,7 @@ mod test {
     fn parse_md5() {
         let mut buff = hex_to_cursor("4D443520 10000000 83F4C759 5E3F9608 378F3B39 D4BEA537");
         let expected = Md5 {
+            offset: Some(0),
             size: 16,
             data: Md5Data {
                 md5: 0x37A5BED4393B8F3708963F5E59C7F483,

--- a/wavrw/src/chunk/plst.rs
+++ b/wavrw/src/chunk/plst.rs
@@ -90,6 +90,7 @@ mod test {
     #[test]
     fn plst_roundtrip() {
         let plst = Plst {
+            offset: Some(0),
             size: 0x1c, // u32 + 2x(3x u32)
             data: PlstData {
                 segment_count: 2,

--- a/wavrw/src/chunk/wavl.rs
+++ b/wavrw/src/chunk/wavl.rs
@@ -139,7 +139,8 @@ mod test {
     // couldn't find slnt usage in file collection, so just doing a roundtrip test
     #[test]
     fn slnt_roundtrip() {
-        let slnt = Slnt {
+        let mut slnt = Slnt {
+            offset: Some(0),
             size: 4,
             data: SlntData { samples: 12345 },
             extra_bytes: Vec::new(),
@@ -155,7 +156,9 @@ mod test {
         assert_eq!(after.summary(), "12345 samples");
 
         // now in a wavl LIST
+        slnt.offset = Some(12);
         let wavl = ListWavl {
+            offset: Some(0),
             size: 16,
             data: ListWavlData {
                 list_type: ListWavlData::LIST_TYPE,
@@ -174,7 +177,8 @@ mod test {
     #[test]
     fn data_in_wavl() {
         // validate data roundtrip
-        let data = Data {
+        let mut data = Data {
+            offset: Some(0),
             size: 0,
             data: DataData {
                 data: [8_u8; 0].to_vec(),
@@ -189,8 +193,10 @@ mod test {
         assert_eq!(after, data);
         println!("length of data as bytes: {}", buff.into_inner().len());
 
+        data.offset = Some(12);
         // finally validate via wavl
         let wavl = ListWavl {
+            offset: Some(0),
             size: 12,
             data: ListWavlData {
                 list_type: ListWavlData::LIST_TYPE,

--- a/wavrw/src/lib.md
+++ b/wavrw/src/lib.md
@@ -7,16 +7,26 @@ Iterate over all dyn [`SizedChunk`] chunk objects from a file:
 ```
 # use std::fs::File;
 # use std::io::BufReader; 
+use wavrw::{Summarizable, SizedChunk}; 
+
 let file = File::open("../test_wavs/example_a.wav")?;
 let file = BufReader::new(file);
 let mut wave = wavrw::Wave::new(file)?;
-for chunk in wave.iter_chunks() {
-    println!(
-        "{:12} {:10} {}",
-        chunk.name(),
-        chunk.size(),
-        chunk.summary()
-    );
+
+for result in wave.iter_chunks() {
+    match result {
+        Ok(chunk) => {
+            println!(
+                "{:12} {:10} {}",
+                chunk.name(),
+                chunk.size(),
+                chunk.summary()
+            )
+        },
+        Err(err) => {
+            println!("{:12} {}", "ERROR".to_string(), err)
+        }
+    }
 }
 # Ok::<(), wavrw::WaveError>(())
 ```
@@ -27,8 +37,7 @@ Or parse a single chunk from a buffer:
 # use binrw::BinRead;
 # use wavrw::testing::hex_to_cursor;
 # let mut buff = hex_to_cursor("666D7420 10000000 01000100 80BB0000 80320200 03001800");
-use wavrw::{SizedChunkEnum, ChunkID, Summarizable};
-use wavrw::FourCC;
+use wavrw::{SizedChunkEnum, ChunkID, Summarizable, FourCC};
 
 let chunk = SizedChunkEnum::read(&mut buff).unwrap();
 

--- a/wavrw/src/lib.md
+++ b/wavrw/src/lib.md
@@ -10,20 +10,13 @@ Iterate over all dyn [`SizedChunk`] chunk objects from a file:
 let file = File::open("../test_wavs/example_a.wav")?;
 let file = BufReader::new(file);
 let mut wave = wavrw::Wave::new(file)?;
-for result in wave.metadata_chunks()? {
-    match result {
-        Ok(chunk) => {
-            println!(
-                "{:12} {:10} {}",
-                chunk.name(),
-                chunk.size(),
-                chunk.summary()
-            );
-        }
-        Err(err) => {
-            println!("ERROR: {err}");
-        }
-    }
+for chunk in wave.iter_chunks() {
+    println!(
+        "{:12} {:10} {}",
+        chunk.name(),
+        chunk.size(),
+        chunk.summary()
+    );
 }
 # Ok::<(), wavrw::WaveError>(())
 ```

--- a/wavrw/src/lib.md
+++ b/wavrw/src/lib.md
@@ -2,7 +2,8 @@ Read (and someday write) wave audio file chunks with a focus on metadata.
 
 This is the API reference documentation, it is a bit dry.
 
-Iterate over all dyn [`SizedChunk`] chunk objects from a file:
+Iterate over all chunk objects from a file, returns [`SizedChunkEnum`]s with
+convenience methods exposed via the [`SizedChunk`] trait:
 
 ```
 # use std::fs::File;

--- a/wavrw/src/lib.md
+++ b/wavrw/src/lib.md
@@ -12,7 +12,7 @@ use wavrw::{Summarizable, SizedChunk};
 
 let file = File::open("../test_wavs/example_a.wav")?;
 let file = BufReader::new(file);
-let mut wave = wavrw::Wave::new(file)?;
+let mut wave = wavrw::Wave::from_reader(file)?;
 
 for result in wave.iter_chunks() {
     match result {

--- a/wavrw/src/lib.rs
+++ b/wavrw/src/lib.rs
@@ -334,9 +334,7 @@ where
 {
     /// Create a new Wave handle. This keeps a reference to the data
     /// until dropped.
-    // TODO: consider renaming to from_reader/from_bufreader to avoid changing interface
-    // when later adding write support
-    pub fn new(mut reader: R) -> Result<Self, WaveError> {
+    pub fn from_reader(mut reader: R) -> Result<Self, WaveError> {
         let riff = Riff::read(&mut reader).map_err(std::io::Error::other)?;
         if riff.form_type != FourCC(*b"WAVE") {
             return Err(WaveError::UnknownFourCC {


### PR DESCRIPTION
- New Wave struct
- metadata_chunks() -> Wave.iter_chunks()
  - iterator, not Vec
  - returns Result<SizedChunkEnum>, much smaller type than before, and still allows error reporting for each chunk.
  - Implemented all of Summarizable trait on SizedChunkEnum, helper methods for getting common chunk data without needing to match and destructure when using.
- WaveErrors enum has variants for all current error conditions, marked #[non_exhaustive]
- let binrw calculate file offset while reading, save it in KnownChunk and expose via Summarizable so CLI can use that instead of its own calculations

closes #70 
